### PR TITLE
About log-archive.service

### DIFF
--- a/exams/LFCS_Practice_Exam_1_Setup.sh
+++ b/exams/LFCS_Practice_Exam_1_Setup.sh
@@ -64,7 +64,7 @@ Description=Log Archiving Service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/log_archive.sh
+ExecStart=/usr/bin/log_archive.sh
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
To generate an error, the ExecStart path should first be incorrect. Initially it should be: ExecStart=/usr/bin/log_archive.sh Once corrected the service will become active (exited)