### PR TITLE
Fix package installation for RHEL compatibility

### DIFF
--- a/exams/LFCS_Practice_Exam_3_Setup.sh
+++ b/exams/LFCS_Practice_Exam_3_Setup.sh
@@ -41,11 +41,6 @@ fi
 # Package Installation
 # ---------------------------------------------------------------------
 echo "[*] Installing required packages..."
-#$PKG_INSTALL podman git nginx netcat-openbsd nfs-utils mdadm || true
-# ---------------------------------------------------------------------
-# Package Installation
-# ---------------------------------------------------------------------
-echo "[*] Installing required packages..."
 
 if [ "$DISTRO" = "rhel" ]; then
     # RHEL packages


### PR DESCRIPTION
- Replace netcat-openbsd with nmap-ncat on RHEL systems
- Use distribution detection for package-specific installs
- Separate RHEL and Debian package lists Tested on RHEL 10 - all packages now install correctly.